### PR TITLE
Set more accurate lower bound on `base`

### DIFF
--- a/deferred-folds.cabal
+++ b/deferred-folds.cabal
@@ -37,7 +37,7 @@ library
     DeferredFolds.Defs.UnfoldrM
     DeferredFolds.Prelude
   build-depends:
-    base >=4.7 && <5,
+    base >=4.9 && <5,
     bytestring >=0.10 && <0.11,
     containers >=0.5 && <0.6,
     foldl >=1 && <2,


### PR DESCRIPTION

Almost all (except for 4 which had a different but related issue) releases of `deferred-folds` suffer from the failure

```
Configuring library for deferred-folds-0.9.1..
Preprocessing library for deferred-folds-0.9.1..
Building library for deferred-folds-0.9.1..

library/DeferredFolds/Prelude.hs:41:8:
    Could not find module ‘Data.Semigroup’
    Use -v to see a list of the files searched for.
<<ghc: 120417240 bytes, 89 GCs, 3928144/8657080 avg/max bytes residency (6 samples), 22M in use, 0.001 INIT (0.001 elapsed), 0.040 MUT (0.045 elapsed), 0.110 GC (0.110 elapsed) :ghc>>
```

I've already revised all 33 affected versions,

 - https://hackage.haskell.org/package/deferred-folds-0.1/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.2/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.2.1/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.2.2/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.2.3/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.3/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.3.0.1/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.4/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.4.0.1/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.4.1/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.5/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.5.1/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.5.2/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.6/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.6.1/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.6.2/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.6.3/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.6.4/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.6.5/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.6.5.1/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.6.6/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.6.7/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.6.8/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.6.9/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.6.10/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.6.11/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.6.12/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.7/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.7.1/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.7.2/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.8/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.9/revisions/
 - https://hackage.haskell.org/package/deferred-folds-0.9.1/revisions/

![deferred-folds](https://user-images.githubusercontent.com/285533/44950295-24033800-ae44-11e8-8684-7ffcd23652ef.png)
