### PR TITLE
make exported overloaded functions inlinable

### DIFF
--- a/library/DeferredFolds/Defs/UnfoldlM.hs
+++ b/library/DeferredFolds/Defs/UnfoldlM.hs
@@ -123,6 +123,7 @@ foldlRunner run = UnfoldlM (\stepM state -> run (\stateM a -> stateM >>= \state 
 foldrRunner :: Monad m => (forall x. (a -> x -> x) -> x -> x) -> UnfoldlM m a
 foldrRunner run = UnfoldlM (\stepM -> run (\x k z -> stepM z x >>= k) return)
 
+{-# INLINABLE unfoldr #-}
 unfoldr :: Monad m => Unfoldr a -> UnfoldlM m a
 unfoldr (Unfoldr unfoldr) = foldrRunner unfoldr
 

--- a/library/DeferredFolds/Defs/Unfoldr.hs
+++ b/library/DeferredFolds/Defs/Unfoldr.hs
@@ -205,42 +205,50 @@ vectorWithIndices vector = Unfoldr $ \step state -> GenericVector.ifoldr (\index
 
 -- |
 -- Binary digits of a non-negative integral number.
+{-# INLINABLE binaryDigits #-}
 binaryDigits :: Integral a => a -> Unfoldr a
 binaryDigits = reverse . reverseBinaryDigits
 
 -- |
 -- Binary digits of a non-negative integral number in reverse order.
+{-# INLINABLE reverseBinaryDigits #-}
 reverseBinaryDigits :: Integral a => a -> Unfoldr a
 reverseBinaryDigits = reverseDigits 2
 
 -- |
 -- Octal digits of a non-negative integral number.
+{-# INLINABLE octalDigits #-}
 octalDigits :: Integral a => a -> Unfoldr a
 octalDigits = reverse . reverseOctalDigits
 
 -- |
 -- Octal digits of a non-negative integral number in reverse order.
+{-# INLINABLE reverseOctalDigits #-}
 reverseOctalDigits :: Integral a => a -> Unfoldr a
 reverseOctalDigits = reverseDigits 8
 
 -- |
 -- Decimal digits of a non-negative integral number.
+{-# INLINABLE decimalDigits #-}
 decimalDigits :: Integral a => a -> Unfoldr a
 decimalDigits = reverse . reverseDecimalDigits
 
 -- |
 -- Decimal digits of a non-negative integral number in reverse order.
 -- More efficient than 'decimalDigits'.
+{-# INLINABLE reverseDecimalDigits #-}
 reverseDecimalDigits :: Integral a => a -> Unfoldr a
 reverseDecimalDigits = reverseDigits 10
 
 -- |
 -- Hexadecimal digits of a non-negative number.
+{-# INLINABLE hexadecimalDigits #-}
 hexadecimalDigits :: Integral a => a -> Unfoldr a
 hexadecimalDigits = reverse . reverseHexadecimalDigits
 
 -- |
 -- Hexadecimal digits of a non-negative number in reverse order.
+{-# INLINABLE reverseHexadecimalDigits #-}
 reverseHexadecimalDigits :: Integral a => a -> Unfoldr a
 reverseHexadecimalDigits = reverseDigits 16
 
@@ -254,6 +262,7 @@ reverseHexadecimalDigits = reverseDigits 16
 -- binaryDigits :: Integral a => a -> Unfoldr a
 -- binaryDigits = 'reverse' . 'reverseDigits' 2
 -- @
+{-# INLINABLE reverseDigits #-}
 reverseDigits ::
   Integral a =>
   -- | Radix
@@ -298,6 +307,7 @@ zipWithReverseIndex (Unfoldr unfoldr) = Unfoldr $ \step init ->
 
 -- |
 -- Indices of set bits.
+{-# INLINABLE setBitIndices #-}
 setBitIndices :: FiniteBits a => a -> Unfoldr Int
 setBitIndices a =
   let !size = finiteBitSize a
@@ -313,6 +323,7 @@ setBitIndices a =
 
 -- |
 -- Indices of unset bits.
+{-# INLINABLE unsetBitIndices #-}
 unsetBitIndices :: FiniteBits a => a -> Unfoldr Int
 unsetBitIndices a =
   let !size = finiteBitSize a


### PR DESCRIPTION
Hi, 

This PR marks each overloaded, non-INLINE/INLINABLE function as INLINABLE. This fixes the "missed specializations" warnings that are emitted when this package is compiled with `-Wmissed-specializations`.